### PR TITLE
Add 'Conflict' notice to launch_template.vpc_security_group_ids

### DIFF
--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -143,7 +143,7 @@ The following arguments are supported:
 * `ram_disk_id` - The ID of the RAM disk.
 * `security_group_names` - A list of security group names to associate with. If you are creating Instances in a VPC, use
   `vpc_security_group_ids` instead.
-* `vpc_security_group_ids` - A list of security group IDs to associate with.
+* `vpc_security_group_ids` - A list of security group IDs to associate with. Conflicts with `network_interfaces.security_groups`
 * `tag_specifications` - The tags to apply to the resources during launch. See [Tag Specifications](#tag-specifications) below for more details.
 * `tags` - (Optional) A mapping of tags to assign to the launch template.
 * `user_data` - The Base64-encoded user data to provide when launching the instance.


### PR DESCRIPTION
Add 'Conflict' notice to launch_template.vpc_security_group_ids

If you supply both `vpc_security_groups_ids` and `network_interfaces.security_groups` you will get back:

```
Error: Error creating AutoScaling Group: InvalidQueryParameter: Invalid launc`h template: When a network interface is provided, the security groups must be a part of it.
        status code: 400, request id: 8821039b-87f1-45ff-8567-74e8b9f21905
```

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
